### PR TITLE
Linting sollte nicht doppelt auf PRs ausgeführt werden

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: markdownlint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   linting:


### PR DESCRIPTION
Durch `push` und `pull_request`-Trigger läuft die Lint-Action bisher immer doppelt auf den PRs 😅 